### PR TITLE
Added height correction feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ How to use
 - Add scenes you wish to be able to paint into the list, and select the one you want to paint
 - Start placing them by left-clicking in the scene. You can remove them using right-click.
   - This will create scene instances as child of the `Scatter3D` node.
+- When the "height correction" checkbox is checked, left clicking will snap colliding objects to the terrain. This is useful if you change the terrain for an existing scene and want to snap some or all of the objects to the new terrain height.
 
 
 License

--- a/addons/zylann.scatter/tools/palette.gd
+++ b/addons/zylann.scatter/tools/palette.gd
@@ -4,6 +4,7 @@ extends Control
 signal pattern_selected(pattern_index)
 signal pattern_added(path)
 signal pattern_removed(path)
+signal heightcorrection_changed(enabled)
 
 onready var _item_list : ItemList = get_node("VBoxContainer/ItemList")
 
@@ -125,3 +126,5 @@ func _on_FileDialog_file_selected(fpath):
 	emit_signal("pattern_added", fpath)
 
 
+func _on_HeightCorrectionCheckBox_toggled(button_pressed):
+	emit_signal("heightcorrection_changed", button_pressed)

--- a/addons/zylann.scatter/tools/palette.tscn
+++ b/addons/zylann.scatter/tools/palette.tscn
@@ -8,6 +8,9 @@ anchor_bottom = 1.0
 margin_right = -874.0
 rect_min_size = Vector2( 150, 0 )
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 anchor_right = 1.0
@@ -16,6 +19,9 @@ margin_left = 4.0
 margin_top = 4.0
 margin_right = -4.0
 margin_bottom = -4.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 margin_right = 142.0
@@ -32,11 +38,22 @@ margin_right = 117.0
 margin_bottom = 20.0
 text = "Remove"
 
-[node name="ItemList" type="ItemList" parent="VBoxContainer"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer"]
 margin_top = 24.0
+margin_right = 142.0
+margin_bottom = 48.0
+
+[node name="HeightCorrectionCheckBox" type="CheckBox" parent="VBoxContainer/HBoxContainer2"]
+margin_right = 139.0
+margin_bottom = 24.0
+text = "Height correction"
+
+[node name="ItemList" type="ItemList" parent="VBoxContainer"]
+margin_top = 52.0
 margin_right = 142.0
 margin_bottom = 592.0
 size_flags_vertical = 3
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/AddButton" to="." method="_on_AddButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/RemoveButton" to="." method="_on_RemoveButton_pressed"]
+[connection signal="toggled" from="VBoxContainer/HBoxContainer2/HeightCorrectionCheckBox" to="." method="_on_HeightCorrectionCheckBox_toggled"]
 [connection signal="item_selected" from="VBoxContainer/ItemList" to="." method="_on_ItemList_item_selected"]


### PR DESCRIPTION
Hello,

I'm new to Godot/GDScript so I apologize for any sloppiness in my approach, or if a solution to this problem already exists and I missed it. Feel free to point out any issues and I'll promptly resolve them or close this pull request if it doesn't make sense.

Problem:
Objects placed by scatter aren't updated on their Y when terrain height is updated in the terrain plugin; nor should they be, since who knows what the author of the scene has intended.

Proposed solution:
Until a more thoughtful UI can be designed, I have simply placed a checkbox with the label "Height correction" which when enabled, repositions colliding objects to match the height of the terrain. This could possibly be enhanced in the future to allow for an offset to be specified.

How to test:
- Place some objects on some terrain using scatter
- Adjust the height of the terrain to cover the objects
- Select the scatter node again, and check the "Height correction" box
- Drag over the area where the objects are and watch as they reappear
- Undo/redo functionality should work as expected

Thank you!