### PR TITLE
Size Variations and aligning Items to Surface

### DIFF
--- a/addons/zylann.scatter/tools/palette.gd
+++ b/addons/zylann.scatter/tools/palette.gd
@@ -136,7 +136,6 @@ func get_configured_size_range() -> Array:
 	size_range[0] = float(_min_size_spin_box.value)/100
 	size_range[1] = float(_max_size_spin_box.value)/100
 	size_range.sort()
-	print(size_range)
 	return size_range
 	
 func get_align_to_normal() -> bool:

--- a/addons/zylann.scatter/tools/palette.gd
+++ b/addons/zylann.scatter/tools/palette.gd
@@ -9,6 +9,10 @@ signal patterns_removed(path)
 
 onready var _item_list : ItemList = get_node("VBoxContainer/ItemList")
 onready var _margin_spin_box : SpinBox = get_node("VBoxContainer/MarginContainer/MarginSpinBox")
+onready var _min_size_spin_box : SpinBox = get_node("VBoxContainer/SizeVarContainer/HBoxContainer/SizeMinSpinBox")
+onready var _max_size_spin_box : SpinBox = get_node("VBoxContainer/SizeVarContainer/HBoxContainer/SizeMaxSpinBox")
+onready var _alignToGround_check_box : CheckBox = get_node("VBoxContainer/AlignVarContainer/AlignToGroundCheckbox")
+onready var _randomizeSize_check_box : CheckBox = get_node("VBoxContainer/SizeVarContainer/HBoxContainer2/RandomizeSizeCheckbox")
 
 var _file_dialog = null
 var _preview_provider : EditorResourcePreview = null
@@ -126,3 +130,27 @@ func can_drop_data(position, data):
 func drop_data(position, data):
 	for file in data.files:
 		emit_signal("pattern_added", file)
+
+func get_configured_size_range() -> Array:
+	var size_range : Array = [1.0,1.0]
+	size_range[0] = float(_min_size_spin_box.value)/100
+	size_range[1] = float(_max_size_spin_box.value)/100
+	size_range.sort()
+	print(size_range)
+	return size_range
+	
+func get_align_to_normal() -> bool:
+	return _alignToGround_check_box.pressed
+
+func get_randomize_size() -> bool:
+	return _randomizeSize_check_box.pressed
+
+#Make sure  Max-Value gets greater/equal Min-Value if needed
+func _on_SizeMinSpinBox_value_changed(value: float) -> void:
+	if _min_size_spin_box.value > _max_size_spin_box.value:
+		_max_size_spin_box.value = _min_size_spin_box.value
+
+#Make sure  Min-Value gets smaller/equal Max-Value if needed
+func _on_SizeMaxSpinBox_value_changed(value: float) -> void:
+	if _max_size_spin_box.value < _min_size_spin_box.value:
+		_min_size_spin_box.value = _max_size_spin_box.value

--- a/addons/zylann.scatter/tools/palette.gd
+++ b/addons/zylann.scatter/tools/palette.gd
@@ -9,10 +9,10 @@ signal patterns_removed(path)
 
 onready var _item_list : ItemList = get_node("VBoxContainer/ItemList")
 onready var _margin_spin_box : SpinBox = get_node("VBoxContainer/MarginContainer/MarginSpinBox")
-onready var _min_size_spin_box : SpinBox = get_node("VBoxContainer/SizeVarContainer/HBoxContainer/SizeMinSpinBox")
-onready var _max_size_spin_box : SpinBox = get_node("VBoxContainer/SizeVarContainer/HBoxContainer/SizeMaxSpinBox")
+onready var _min_size_spin_box : SpinBox = get_node("VBoxContainer/SizeVarContainer/HBoxRangeRandom/SizeMinSpinBox")
+onready var _max_size_spin_box : SpinBox = get_node("VBoxContainer/SizeVarContainer/HBoxRangeRandom/SizeMaxSpinBox")
 onready var _alignToGround_check_box : CheckBox = get_node("VBoxContainer/AlignVarContainer/AlignToGroundCheckbox")
-onready var _randomizeSize_check_box : CheckBox = get_node("VBoxContainer/SizeVarContainer/HBoxContainer2/RandomizeSizeCheckbox")
+onready var _randomizeSize_check_box : CheckBox = get_node("VBoxContainer/SizeVarContainer/HBoxToggleRandom/RandomizeSizeCheckbox")
 
 var _file_dialog = null
 var _preview_provider : EditorResourcePreview = null

--- a/addons/zylann.scatter/tools/palette.tscn
+++ b/addons/zylann.scatter/tools/palette.tscn
@@ -76,17 +76,17 @@ margin_top = 512.0
 margin_right = 202.0
 margin_bottom = 564.0
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/SizeVarContainer"]
+[node name="HBoxToggleRandom" type="HBoxContainer" parent="VBoxContainer/SizeVarContainer"]
 margin_right = 202.0
 margin_bottom = 24.0
 
-[node name="SizeVarLabel" type="Label" parent="VBoxContainer/SizeVarContainer/HBoxContainer2"]
+[node name="SizeVarLabel" type="Label" parent="VBoxContainer/SizeVarContainer/HBoxToggleRandom"]
 margin_top = 5.0
 margin_right = 141.0
 margin_bottom = 19.0
 text = "  Size variation (%):     "
 
-[node name="RandomizeSizeCheckbox" type="CheckBox" parent="VBoxContainer/SizeVarContainer/HBoxContainer2"]
+[node name="RandomizeSizeCheckbox" type="CheckBox" parent="VBoxContainer/SizeVarContainer/HBoxToggleRandom"]
 margin_left = 145.0
 margin_right = 169.0
 margin_bottom = 24.0
@@ -94,18 +94,18 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/SizeVarContainer"]
+[node name="HBoxRangeRandom" type="HBoxContainer" parent="VBoxContainer/SizeVarContainer"]
 margin_top = 28.0
 margin_right = 202.0
 margin_bottom = 52.0
 
-[node name="MinSizeLabel" type="Label" parent="VBoxContainer/SizeVarContainer/HBoxContainer"]
+[node name="MinSizeLabel" type="Label" parent="VBoxContainer/SizeVarContainer/HBoxRangeRandom"]
 margin_top = 5.0
 margin_right = 4.0
 margin_bottom = 19.0
 text = " "
 
-[node name="SizeMinSpinBox" type="SpinBox" parent="VBoxContainer/SizeVarContainer/HBoxContainer"]
+[node name="SizeMinSpinBox" type="SpinBox" parent="VBoxContainer/SizeVarContainer/HBoxRangeRandom"]
 margin_left = 8.0
 margin_right = 82.0
 margin_bottom = 24.0
@@ -116,14 +116,14 @@ allow_greater = true
 align = 2
 suffix = "%"
 
-[node name="MaxSizeLabel" type="Label" parent="VBoxContainer/SizeVarContainer/HBoxContainer"]
+[node name="MaxSizeLabel" type="Label" parent="VBoxContainer/SizeVarContainer/HBoxRangeRandom"]
 margin_left = 86.0
 margin_top = 5.0
 margin_right = 103.0
 margin_bottom = 19.0
 text = "to:"
 
-[node name="SizeMaxSpinBox" type="SpinBox" parent="VBoxContainer/SizeVarContainer/HBoxContainer"]
+[node name="SizeMaxSpinBox" type="SpinBox" parent="VBoxContainer/SizeVarContainer/HBoxRangeRandom"]
 margin_left = 107.0
 margin_right = 181.0
 margin_bottom = 24.0
@@ -153,5 +153,5 @@ margin_bottom = 24.0
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/AddButton" to="." method="_on_AddButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/RemoveButton" to="." method="_on_RemoveButton_pressed"]
 [connection signal="multi_selected" from="VBoxContainer/ItemList" to="." method="_on_ItemList_multi_selected"]
-[connection signal="value_changed" from="VBoxContainer/SizeVarContainer/HBoxContainer/SizeMinSpinBox" to="." method="_on_SizeMinSpinBox_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/SizeVarContainer/HBoxContainer/SizeMaxSpinBox" to="." method="_on_SizeMaxSpinBox_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/SizeVarContainer/HBoxRangeRandom/SizeMinSpinBox" to="." method="_on_SizeMinSpinBox_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/SizeVarContainer/HBoxRangeRandom/SizeMaxSpinBox" to="." method="_on_SizeMaxSpinBox_value_changed"]

--- a/addons/zylann.scatter/tools/palette.tscn
+++ b/addons/zylann.scatter/tools/palette.tscn
@@ -42,35 +42,116 @@ text = "Remove"
 [node name="ItemList" type="ItemList" parent="VBoxContainer"]
 margin_top = 24.0
 margin_right = 202.0
-margin_bottom = 564.0
+margin_bottom = 480.0
+size_flags_horizontal = 3
 size_flags_vertical = 3
 select_mode = 1
 
 [node name="MarginContainer" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 568.0
+margin_top = 484.0
 margin_right = 202.0
-margin_bottom = 592.0
+margin_bottom = 508.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="MarginLabel" type="Label" parent="VBoxContainer/MarginContainer"]
 margin_top = 5.0
-margin_right = 99.0
+margin_right = 124.0
 margin_bottom = 19.0
 size_flags_horizontal = 3
 text = "Object margin:"
 align = 1
 
 [node name="MarginSpinBox" type="SpinBox" parent="VBoxContainer/MarginContainer"]
-margin_left = 103.0
+margin_left = 128.0
 margin_right = 202.0
 margin_bottom = 24.0
-size_flags_horizontal = 3
 max_value = 10.0
 step = 0.01
 allow_greater = true
 
+[node name="SizeVarContainer" type="VBoxContainer" parent="VBoxContainer"]
+margin_top = 512.0
+margin_right = 202.0
+margin_bottom = 564.0
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/SizeVarContainer"]
+margin_right = 202.0
+margin_bottom = 24.0
+
+[node name="SizeVarLabel" type="Label" parent="VBoxContainer/SizeVarContainer/HBoxContainer2"]
+margin_top = 5.0
+margin_right = 141.0
+margin_bottom = 19.0
+text = "  Size variation (%):     "
+
+[node name="RandomizeSizeCheckbox" type="CheckBox" parent="VBoxContainer/SizeVarContainer/HBoxContainer2"]
+margin_left = 145.0
+margin_right = 169.0
+margin_bottom = 24.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/SizeVarContainer"]
+margin_top = 28.0
+margin_right = 202.0
+margin_bottom = 52.0
+
+[node name="MinSizeLabel" type="Label" parent="VBoxContainer/SizeVarContainer/HBoxContainer"]
+margin_top = 5.0
+margin_right = 4.0
+margin_bottom = 19.0
+text = " "
+
+[node name="SizeMinSpinBox" type="SpinBox" parent="VBoxContainer/SizeVarContainer/HBoxContainer"]
+margin_left = 8.0
+margin_right = 82.0
+margin_bottom = 24.0
+min_value = 10.0
+max_value = 200.0
+value = 100.0
+allow_greater = true
+align = 2
+suffix = "%"
+
+[node name="MaxSizeLabel" type="Label" parent="VBoxContainer/SizeVarContainer/HBoxContainer"]
+margin_left = 86.0
+margin_top = 5.0
+margin_right = 103.0
+margin_bottom = 19.0
+text = "to:"
+
+[node name="SizeMaxSpinBox" type="SpinBox" parent="VBoxContainer/SizeVarContainer/HBoxContainer"]
+margin_left = 107.0
+margin_right = 181.0
+margin_bottom = 24.0
+min_value = 10.0
+max_value = 200.0
+value = 100.0
+allow_greater = true
+align = 2
+suffix = "%"
+
+[node name="AlignVarContainer" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 568.0
+margin_right = 202.0
+margin_bottom = 592.0
+
+[node name="AlignToGroundLabel" type="Label" parent="VBoxContainer/AlignVarContainer"]
+margin_top = 5.0
+margin_right = 141.0
+margin_bottom = 19.0
+text = "  Align to ground:        "
+
+[node name="AlignToGroundCheckbox" type="CheckBox" parent="VBoxContainer/AlignVarContainer"]
+margin_left = 145.0
+margin_right = 169.0
+margin_bottom = 24.0
+
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/AddButton" to="." method="_on_AddButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/RemoveButton" to="." method="_on_RemoveButton_pressed"]
 [connection signal="multi_selected" from="VBoxContainer/ItemList" to="." method="_on_ItemList_multi_selected"]
+[connection signal="value_changed" from="VBoxContainer/SizeVarContainer/HBoxContainer/SizeMinSpinBox" to="." method="_on_SizeMinSpinBox_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/SizeVarContainer/HBoxContainer/SizeMaxSpinBox" to="." method="_on_SizeMaxSpinBox_value_changed"]

--- a/addons/zylann.scatter/tools/plugin.gd
+++ b/addons/zylann.scatter/tools/plugin.gd
@@ -192,6 +192,16 @@ func _paint(ray_origin: Vector3, ray_end: Vector3):
 			_node.add_child(instance)
 			instance.owner = get_editor_interface().get_edited_scene_root()
 			_placed_instances.append(instance)
+			
+			if _palette.get_align_to_normal():
+				var hit_normal = hit.normal.normalized()
+				var xform = Util.align_with_y(instance.global_transform, hit_normal)
+				instance.global_transform = xform
+			
+			if _palette.get_randomize_size():
+				var size_range = _palette.get_configured_size_range()
+				var rand_scale = rand_range(size_range[0],size_range[1])
+				instance.scale = Vector3(rand_scale,rand_scale,rand_scale)
 
 
 func _erase(ray_origin: Vector3, ray_dir: Vector3):

--- a/addons/zylann.scatter/util/util.gd
+++ b/addons/zylann.scatter/util/util.gd
@@ -42,3 +42,9 @@ static func is_self_or_parent_scene(fpath, node):
 	return false
 
 
+static func align_with_y(xform, new_y) -> Transform:
+	xform.basis.y = new_y
+	xform.basis.x = -xform.basis.z.cross(new_y)
+	xform.basis = xform.basis.orthonormalized()
+	return xform
+


### PR DESCRIPTION
This adds two new functionalities to the scatter-Plugin:

A) Enable  random size variations in size for the scattered Items. Toggle on and off, give an upper and a lower limit for the size variations.

B) Aligning scattered items with the surface they stand on. Toggle on an off. Looks fine with flat items such rocks and crates, probably quite strange for trees and pillars.

(I accidentally deleted my former pull request. Still learning how to git good. Hope I got it right this time)